### PR TITLE
Bytes plugin fix and cdifflib

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ license = {text = "MIT"}
 authors = [{name = "Axel Mierczuk"}]
 requires-python = ">=3.10"
 dependencies = [
-    "cdifflib==1.2.9",
+    "cdifflib==1.2.9; sys_platform != 'win32'", # Optional dependency for better diffing with IDA
     "fastmcp>=2.12.3",
     "gunicorn>=23.0.0",
     "ida-domain==0.2.0",

--- a/tenrec/plugins/plugins/bytes.py
+++ b/tenrec/plugins/plugins/bytes.py
@@ -1,4 +1,5 @@
 from enum import Enum
+from typing import Literal
 
 from ida_domain.bytes import ByteFlags, SearchFlags
 from ida_domain.strings import StringType
@@ -35,6 +36,24 @@ class DataType(Enum):
     ALIGNMENT = "alignment"
 
 
+DataTypeLiteral = Literal[
+    "byte",
+    "word",
+    "dword",
+    "qword",
+    "oword",
+    "yword",
+    "zword",
+    "tbyte",
+    "float",
+    "double",
+    "packed_real",
+    "string",
+    "struct",
+    "alignment",
+]
+
+
 class BytesPlugin(PluginBase):
     """Plugin for managing raw bytes, data definitions, and low-level memory operations in the IDA database."""
 
@@ -68,8 +87,8 @@ class BytesPlugin(PluginBase):
     @operation()
     def create_data_at(
         self,
-        ea: HexEA,
-        data_type: DataType,
+        address: HexEA,
+        data_type: DataTypeLiteral,
         count: int = 1,
         force: bool = False,
         length: int | None = None,
@@ -79,7 +98,7 @@ class BytesPlugin(PluginBase):
     ) -> bool:
         """Create data items of specified type at consecutive addresses.
 
-        :param ea: Starting address for data definitions.
+        :param address: Starting address for data definitions.
         :param data_type: Type of data to create (DataType enum). Options are:
             `BYTE`: *byte (1 byte)*
             `WORD`: *word (2 bytes)*
@@ -112,48 +131,51 @@ class BytesPlugin(PluginBase):
         :param alignment: Power of 2 alignment (for DataType.ALIGNMENT).
         :return: True if data was successfully defined, False otherwise.
         """
+        data_type = DataType(data_type)
         match data_type:
             case DataType.BYTE:
-                return self.database.bytes.create_byte_at(ea.ea_t, count, force)
+                return self.database.bytes.create_byte_at(address.ea_t, count, force)
             case DataType.WORD:
-                return self.database.bytes.create_word_at(ea.ea_t, count, force)
+                return self.database.bytes.create_word_at(address.ea_t, count, force)
             case DataType.DWORD:
-                return self.database.bytes.create_dword_at(ea.ea_t, count, force)
+                return self.database.bytes.create_dword_at(address.ea_t, count, force)
             case DataType.QWORD:
-                return self.database.bytes.create_qword_at(ea.ea_t, count, force)
+                return self.database.bytes.create_qword_at(address.ea_t, count, force)
             case DataType.OWORD:
-                return self.database.bytes.create_oword_at(ea.ea_t, count, force)
+                return self.database.bytes.create_oword_at(address.ea_t, count, force)
             case DataType.YWORD:
-                return self.database.bytes.create_yword_at(ea.ea_t, count, force)
+                return self.database.bytes.create_yword_at(address.ea_t, count, force)
             case DataType.ZWORD:
-                return self.database.bytes.create_zword_at(ea.ea_t, count, force)
+                return self.database.bytes.create_zword_at(address.ea_t, count, force)
             case DataType.TBYTE:
-                return self.database.bytes.create_tbyte_at(ea.ea_t, count, force)
+                return self.database.bytes.create_tbyte_at(address.ea_t, count, force)
             case DataType.FLOAT:
-                return self.database.bytes.create_float_at(ea.ea_t, count, force)
+                return self.database.bytes.create_float_at(address.ea_t, count, force)
             case DataType.DOUBLE:
-                return self.database.bytes.create_double_at(ea.ea_t, count, force)
+                return self.database.bytes.create_double_at(address.ea_t, count, force)
             case DataType.PACKED_REAL:
-                return self.database.bytes.create_packed_real_at(ea.ea_t, count, force)
+                return self.database.bytes.create_packed_real_at(address.ea_t, count, force)
             case DataType.STRING:
-                return self.database.bytes.create_string_at(ea.ea_t, length, string_type)
+                return self.database.bytes.create_string_at(address.ea_t, length, string_type)
             case DataType.STRUCT:
                 if tid is None:
                     msg = "tid parameter required for struct creation"
                     raise OperationError(msg)
-                return self.database.bytes.create_struct_at(ea.ea_t, count, tid, force)
+                return self.database.bytes.create_struct_at(address.ea_t, count, tid, force)
             case DataType.ALIGNMENT:
                 length_val = length if length is not None else 0
-                return self.database.bytes.create_alignment_at(ea.ea_t, length_val, alignment)
+                return self.database.bytes.create_alignment_at(address.ea_t, length_val, alignment)
             case _:
                 msg = f"Unsupported data type: {data_type}"
                 raise OperationError(msg)
 
     @operation()
-    def get_value_at(self, ea: HexEA, data_type: DataType, allow_uninitialized: bool = False) -> int | float | str:
+    def get_value_at(
+        self, address: HexEA, data_type: DataTypeLiteral, allow_uninitialized: bool = False
+    ) -> int | float | str:
         """Read a value of specified type from memory.
 
-        :param ea: The effective address to read from.
+        :param address: The effective address to read from.
         :param data_type: Type of data to create (DataType enum). Options are:
             `BYTE`: *byte (1 byte)*
             `WORD`: *word (2 bytes)*
@@ -172,31 +194,32 @@ class BytesPlugin(PluginBase):
         :param allow_uninitialized: Allow reading uninitialized memory if True.
         :return: Value read from memory (type depends on data_type).
         """
+        data_type = DataType(data_type)
         match data_type:
             case DataType.BYTE:
-                return self.database.bytes.get_byte_at(ea.ea_t, allow_uninitialized)
+                return self.database.bytes.get_byte_at(address.ea_t, allow_uninitialized)
             case DataType.WORD:
-                return self.database.bytes.get_word_at(ea.ea_t, allow_uninitialized)
+                return self.database.bytes.get_word_at(address.ea_t, allow_uninitialized)
             case DataType.DWORD:
-                return self.database.bytes.get_dword_at(ea.ea_t, allow_uninitialized)
+                return self.database.bytes.get_dword_at(address.ea_t, allow_uninitialized)
             case DataType.QWORD:
-                return self.database.bytes.get_qword_at(ea.ea_t, allow_uninitialized)
+                return self.database.bytes.get_qword_at(address.ea_t, allow_uninitialized)
             case DataType.FLOAT:
-                result = self.database.bytes.get_float_at(ea.ea_t, allow_uninitialized)
+                result = self.database.bytes.get_float_at(address.ea_t, allow_uninitialized)
                 if result is None:
-                    msg = f"Could not get float at '{ea}' in database"
+                    msg = f"Could not get float at '{address}' in database"
                     raise OperationError(msg)
                 return result
             case DataType.DOUBLE:
-                result = self.database.bytes.get_double_at(ea.ea_t, allow_uninitialized)
+                result = self.database.bytes.get_double_at(address.ea_t, allow_uninitialized)
                 if result is None:
-                    msg = f"Could not get double at '{ea}' in database"
+                    msg = f"Could not get double at '{address}' in database"
                     raise OperationError(msg)
                 return result
             case DataType.STRING:
-                result = self.database.bytes.get_string_at(ea.ea_t)
+                result = self.database.bytes.get_string_at(address.ea_t)
                 if result is None:
-                    msg = f"Could not get string at '{ea}' in database"
+                    msg = f"Could not get string at '{address}' in database"
                     raise OperationError(msg)
                 return result
             case _:
@@ -204,10 +227,10 @@ class BytesPlugin(PluginBase):
                 raise OperationError(msg)
 
     @operation()
-    def is_type_at(self, ea: HexEA, data_type: DataType) -> bool:
+    def is_type_at(self, address: HexEA, data_type: DataTypeLiteral) -> bool:
         """Check if address contains a specific data type.
 
-        :param ea: The effective address to check.
+        :param address: The effective address to check.
         :param data_type: Type of data to create (DataType enum). Options are:
             `BYTE`: *byte (1 byte)*
             `WORD`: *word (2 bytes)*
@@ -225,47 +248,48 @@ class BytesPlugin(PluginBase):
             `ALIGNMENT`: *alignment (requires length or alignment parameter)*
         :return: True if address contains the specified type, False otherwise.
         """
+        data_type = DataType(data_type)
         match data_type:
             case DataType.BYTE:
-                return self.database.bytes.is_byte_at(ea.ea_t)
+                return self.database.bytes.is_byte_at(address.ea_t)
             case DataType.WORD:
-                return self.database.bytes.is_word_at(ea.ea_t)
+                return self.database.bytes.is_word_at(address.ea_t)
             case DataType.DWORD:
-                return self.database.bytes.is_dword_at(ea.ea_t)
+                return self.database.bytes.is_dword_at(address.ea_t)
             case DataType.QWORD:
-                return self.database.bytes.is_qword_at(ea.ea_t)
+                return self.database.bytes.is_qword_at(address.ea_t)
             case DataType.OWORD:
-                return self.database.bytes.is_oword_at(ea.ea_t)
+                return self.database.bytes.is_oword_at(address.ea_t)
             case DataType.YWORD:
-                return self.database.bytes.is_yword_at(ea.ea_t)
+                return self.database.bytes.is_yword_at(address.ea_t)
             case DataType.ZWORD:
-                return self.database.bytes.is_zword_at(ea.ea_t)
+                return self.database.bytes.is_zword_at(address.ea_t)
             case DataType.TBYTE:
-                return self.database.bytes.is_tbyte_at(ea.ea_t)
+                return self.database.bytes.is_tbyte_at(address.ea_t)
             case DataType.FLOAT:
-                return self.database.bytes.is_float_at(ea.ea_t)
+                return self.database.bytes.is_float_at(address.ea_t)
             case DataType.DOUBLE:
-                return self.database.bytes.is_double_at(ea.ea_t)
+                return self.database.bytes.is_double_at(address.ea_t)
             case DataType.PACKED_REAL:
-                return self.database.bytes.is_packed_real_at(ea.ea_t)
+                return self.database.bytes.is_packed_real_at(address.ea_t)
             case DataType.STRING:
-                return self.database.bytes.is_string_literal_at(ea.ea_t)
+                return self.database.bytes.is_string_literal_at(address.ea_t)
             case DataType.STRUCT:
-                return self.database.bytes.is_struct_at(ea.ea_t)
+                return self.database.bytes.is_struct_at(address.ea_t)
             case DataType.ALIGNMENT:
-                return self.database.bytes.is_alignment_at(ea.ea_t)
+                return self.database.bytes.is_alignment_at(address.ea_t)
 
     @operation()
-    def patch_value_at(self, ea: HexEA, value: int | bytes, data_type: DataType = None) -> bool:
+    def patch_value_at(self, address: HexEA, value: int | bytes, data_type: DataTypeLiteral | None = None) -> bool:
         """Patch a value in the database (original value is preserved).
 
-        :param ea: Address to patch.
+        :param address: Address to patch.
         :param value: New value to write.
         :param data_type: Type of data to patch (auto-detect from value if None).
         :return: True if patch applied, False otherwise.
         """
         if isinstance(value, bytes):
-            self.database.bytes.patch_bytes_at(ea.ea_t, value)
+            self.database.bytes.patch_bytes_at(address.ea_t, value)
             return True
 
         if data_type is None:
@@ -277,31 +301,33 @@ class BytesPlugin(PluginBase):
                 data_type = DataType.DWORD
             else:
                 data_type = DataType.QWORD
+        else:
+            data_type = DataType(data_type)
 
         match data_type:
             case DataType.BYTE:
-                return self.database.bytes.patch_byte_at(ea.ea_t, value)
+                return self.database.bytes.patch_byte_at(address.ea_t, value)
             case DataType.WORD:
-                return self.database.bytes.patch_word_at(ea.ea_t, value)
+                return self.database.bytes.patch_word_at(address.ea_t, value)
             case DataType.DWORD:
-                return self.database.bytes.patch_dword_at(ea.ea_t, value)
+                return self.database.bytes.patch_dword_at(address.ea_t, value)
             case DataType.QWORD:
-                return self.database.bytes.patch_qword_at(ea.ea_t, value)
+                return self.database.bytes.patch_qword_at(address.ea_t, value)
             case _:
                 msg = f"Unsupported data type for patching: {data_type}"
                 raise OperationError(msg)
 
     @operation()
-    def set_value_at(self, ea: HexEA, value: int | bytes, data_type: DataType = None) -> bool:
+    def set_value_at(self, address: HexEA, value: int | bytes, data_type: DataTypeLiteral | None = None) -> bool:
         """Set a value at the specified address.
 
-        :param ea: The effective address.
+        :param address: The effective address.
         :param value: Value to set.
         :param data_type: Type of data to set (auto-detect from value if None).
         :return: True if successful, False otherwise.
         """
         if isinstance(value, bytes):
-            self.database.bytes.set_bytes_at(ea.ea_t, value)
+            self.database.bytes.set_bytes_at(address.ea_t, value)
             return True
 
         if data_type is None:
@@ -313,46 +339,49 @@ class BytesPlugin(PluginBase):
                 data_type = DataType.DWORD
             else:
                 data_type = DataType.QWORD
+        else:
+            data_type = DataType(data_type)
 
         match data_type:
             case DataType.BYTE:
-                return self.database.bytes.set_byte_at(ea.ea_t, value)
+                return self.database.bytes.set_byte_at(address.ea_t, value)
             case DataType.WORD:
-                self.database.bytes.set_word_at(ea.ea_t, value)
+                self.database.bytes.set_word_at(address.ea_t, value)
                 return True
             case DataType.DWORD:
-                self.database.bytes.set_dword_at(ea.ea_t, value)
+                self.database.bytes.set_dword_at(address.ea_t, value)
                 return True
             case DataType.QWORD:
-                self.database.bytes.set_qword_at(ea.ea_t, value)
+                self.database.bytes.set_qword_at(address.ea_t, value)
                 return True
             case _:
                 msg = f"Unsupported data type for setting: {data_type}"
                 raise OperationError(msg)
 
     @operation()
-    def get_original_value_at(self, ea: HexEA, data_type: DataType) -> int:
+    def get_original_value_at(self, address: HexEA, data_type: DataTypeLiteral) -> int:
         """Get original value (before patching) at address.
 
-        :param ea: The effective address.
+        :param address: The effective address.
         :param data_type: Type of data to read (DataType enum).
         :return: The original value.
         """
         result = None
+        data_type = DataType(data_type)
         match data_type:
             case DataType.BYTE:
-                result = self.database.bytes.get_original_byte_at(ea.ea_t)
+                result = self.database.bytes.get_original_byte_at(address.ea_t)
             case DataType.WORD:
-                result = self.database.bytes.get_original_word_at(ea.ea_t)
+                result = self.database.bytes.get_original_word_at(address.ea_t)
             case DataType.DWORD:
-                result = self.database.bytes.get_original_dword_at(ea.ea_t)
+                result = self.database.bytes.get_original_dword_at(address.ea_t)
             case DataType.QWORD:
-                result = self.database.bytes.get_original_qword_at(ea.ea_t)
+                result = self.database.bytes.get_original_qword_at(address.ea_t)
             case _:
                 msg = f"Unsupported data type for getting original: {data_type}"
                 raise OperationError(msg)
         if result is None:
-            msg = f"Could not get original {data_type.value} at '{ea}' in database"
+            msg = f"Could not get original {data_type.value} at '{address}' in database"
             raise OperationError(msg)
         return result
 
@@ -418,7 +447,7 @@ class BytesPlugin(PluginBase):
 
     @operation()
     def find_text_between(
-        self, text: str, start_ea: HexEA = None, end_ea: HexEA = None, flags: SearchFlags = SearchFlags.DOWN
+        self, text: str, start_ea: HexEA, end_ea: HexEA, flags: SearchFlags = SearchFlags.DOWN
     ) -> HexEA:
         """Search for text string in disassembly, comments, or data.
 

--- a/tenrec/plugins/plugins/bytes.py
+++ b/tenrec/plugins/plugins/bytes.py
@@ -423,7 +423,10 @@ class BytesPlugin(PluginBase):
             msg = "Pattern must be a hex string (e.g., '9090' for two NOPs)"
             raise OperationError(msg)
 
-        result = self.database.bytes.find_bytes_between(pattern, start_ea.ea_t, end_ea.ea_t)
+        start_ea = start_ea.ea_t if start_ea is not None else None
+        end_ea = end_ea.ea_t if end_ea is not None else None
+
+        result = self.database.bytes.find_bytes_between(pattern, start_ea, end_ea)
         if result is None:
             msg = f"Could not find byte pattern '{pattern}' in database"
             raise OperationError(msg)
@@ -439,7 +442,10 @@ class BytesPlugin(PluginBase):
         :return: HexEA address of instruction containing the immediate.
         :raises OperationException: If immediate value not found.
         """
-        result = self.database.bytes.find_immediate_between(value, start_ea.ea_t, end_ea.ea_t)
+        start_ea = start_ea.ea_t if start_ea is not None else None
+        end_ea = end_ea.ea_t if end_ea is not None else None
+
+        result = self.database.bytes.find_immediate_between(value, start_ea, end_ea)
         if result is None:
             msg = f"Could not find byte pattern '{value}' in database"
             raise OperationError(msg)
@@ -447,7 +453,7 @@ class BytesPlugin(PluginBase):
 
     @operation()
     def find_text_between(
-        self, text: str, start_ea: HexEA, end_ea: HexEA, flags: SearchFlags = SearchFlags.DOWN
+        self, text: str, start_ea: HexEA = None, end_ea: HexEA = None, flags: SearchFlags = SearchFlags.DOWN
     ) -> HexEA:
         """Search for text string in disassembly, comments, or data.
 
@@ -458,7 +464,10 @@ class BytesPlugin(PluginBase):
         :return: HexEA address where text was found.
         :raises OperationException: If text not found.
         """
-        result = self.database.bytes.find_text_between(text, start_ea.ea_t, end_ea.ea_t, flags)
+        start_ea = start_ea.ea_t if start_ea is not None else None
+        end_ea = end_ea.ea_t if end_ea is not None else None
+
+        result = self.database.bytes.find_text_between(text, start_ea, end_ea, flags)
         if result is None:
             msg = f"Could not find text '{text}' in database between '{start_ea}' and '{end_ea}'"
             raise OperationError(msg)

--- a/uv.lock
+++ b/uv.lock
@@ -61,6 +61,12 @@ name = "cdifflib"
 version = "1.2.9"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/52/aa/daefb1236e47561ca53f469f4832f625b38ad6db4e5c68e589dd72928d61/cdifflib-1.2.9.tar.gz", hash = "sha256:6286da08f72b7ddb5b40145dcb8f214ad913a86d72b1f62cc8d6cf7a92029590", size = 12323, upload-time = "2025-01-13T22:18:04.625Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0a/2a/12cc95269e666ac40a20662c865677e24363fdca4d5c72566ad36b14d24a/cdifflib-1.2.9-cp310-cp310-macosx_15_0_arm64.whl", hash = "sha256:24219193d1d298ead211d4b628ad2124ffa1c0676890cea8fbacdeaf66a2369b", size = 11044, upload-time = "2025-01-13T22:17:55.548Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/35/161f137709a77ae861dfdebb478a7dad323b3a7fd3c24b97799ccf48a2b7/cdifflib-1.2.9-cp311-cp311-macosx_15_0_arm64.whl", hash = "sha256:32c56f7895253b0734f42ba023a9c181b52d72f3d51afacc29d5ea8ee72e4643", size = 11046, upload-time = "2025-01-13T22:17:58.077Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/94/caf01d3efe4aa31086217d20538ad9a8ef8a925b49771d34d4dab0295de8/cdifflib-1.2.9-cp312-cp312-macosx_15_0_arm64.whl", hash = "sha256:75a81d8a5e2b0ca055d3f7850fd0a29b488b086c91445841fa3113ac328410e0", size = 11028, upload-time = "2025-01-13T22:17:59.168Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/05/5071e0757237e7aa79a6256c1ddddebebab500e1807a1603739f777f37b1/cdifflib-1.2.9-cp313-cp313-macosx_15_0_arm64.whl", hash = "sha256:c7113c018e1d8190ce6c00318ae5afe7e99c8e4e0b4b631ee79acde74949c2e8", size = 11039, upload-time = "2025-01-13T22:18:01.439Z" },
+]
 
 [[package]]
 name = "certifi"
@@ -1527,10 +1533,10 @@ wheels = [
 
 [[package]]
 name = "tenrec"
-version = "0.1.8"
+version = "0.1.9"
 source = { editable = "." }
 dependencies = [
-    { name = "cdifflib", marker = "sys_platform == 'win32'" },
+    { name = "cdifflib", marker = "sys_platform != 'win32'" },
     { name = "fastmcp" },
     { name = "gitpython" },
     { name = "giturlparse" },
@@ -1556,7 +1562,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "cdifflib", marker = "sys_platform == 'win32'", specifier = "==1.2.9" },
+    { name = "cdifflib", marker = "sys_platform != 'win32'", specifier = "==1.2.9" },
     { name = "fastmcp", specifier = ">=2.12.3" },
     { name = "gitpython", specifier = ">=3.1.45" },
     { name = "giturlparse", specifier = ">=0.12.0" },

--- a/uv.lock
+++ b/uv.lock
@@ -61,12 +61,6 @@ name = "cdifflib"
 version = "1.2.9"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/52/aa/daefb1236e47561ca53f469f4832f625b38ad6db4e5c68e589dd72928d61/cdifflib-1.2.9.tar.gz", hash = "sha256:6286da08f72b7ddb5b40145dcb8f214ad913a86d72b1f62cc8d6cf7a92029590", size = 12323, upload-time = "2025-01-13T22:18:04.625Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/0a/2a/12cc95269e666ac40a20662c865677e24363fdca4d5c72566ad36b14d24a/cdifflib-1.2.9-cp310-cp310-macosx_15_0_arm64.whl", hash = "sha256:24219193d1d298ead211d4b628ad2124ffa1c0676890cea8fbacdeaf66a2369b", size = 11044, upload-time = "2025-01-13T22:17:55.548Z" },
-    { url = "https://files.pythonhosted.org/packages/ba/35/161f137709a77ae861dfdebb478a7dad323b3a7fd3c24b97799ccf48a2b7/cdifflib-1.2.9-cp311-cp311-macosx_15_0_arm64.whl", hash = "sha256:32c56f7895253b0734f42ba023a9c181b52d72f3d51afacc29d5ea8ee72e4643", size = 11046, upload-time = "2025-01-13T22:17:58.077Z" },
-    { url = "https://files.pythonhosted.org/packages/cd/94/caf01d3efe4aa31086217d20538ad9a8ef8a925b49771d34d4dab0295de8/cdifflib-1.2.9-cp312-cp312-macosx_15_0_arm64.whl", hash = "sha256:75a81d8a5e2b0ca055d3f7850fd0a29b488b086c91445841fa3113ac328410e0", size = 11028, upload-time = "2025-01-13T22:17:59.168Z" },
-    { url = "https://files.pythonhosted.org/packages/7c/05/5071e0757237e7aa79a6256c1ddddebebab500e1807a1603739f777f37b1/cdifflib-1.2.9-cp313-cp313-macosx_15_0_arm64.whl", hash = "sha256:c7113c018e1d8190ce6c00318ae5afe7e99c8e4e0b4b631ee79acde74949c2e8", size = 11039, upload-time = "2025-01-13T22:18:01.439Z" },
-]
 
 [[package]]
 name = "certifi"
@@ -1533,10 +1527,10 @@ wheels = [
 
 [[package]]
 name = "tenrec"
-version = "0.1.5"
+version = "0.1.8"
 source = { editable = "." }
 dependencies = [
-    { name = "cdifflib" },
+    { name = "cdifflib", marker = "sys_platform == 'win32'" },
     { name = "fastmcp" },
     { name = "gitpython" },
     { name = "giturlparse" },
@@ -1562,7 +1556,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "cdifflib", specifier = "==1.2.9" },
+    { name = "cdifflib", marker = "sys_platform == 'win32'", specifier = "==1.2.9" },
     { name = "fastmcp", specifier = ">=2.12.3" },
     { name = "gitpython", specifier = ">=3.1.45" },
     { name = "giturlparse", specifier = ">=0.12.0" },


### PR DESCRIPTION
In reference to issue #3 , this PR:

- Removed `cdifflib` as a dependency on Windows
- Updates the bytes plugin to use literals instead of enums as arguments for `data_type`. 
- Fixes a bug in the "between" functions for bytes where `ea_t` would be references even if `start_ea` or `end_ea` were `None`.

After testing locally with `darn_mice.exe`, this seems to fix things.