### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,4 +1,6 @@
 name: Publish to PyPI
+permissions:
+  contents: read
 on:
   push:
     tags:


### PR DESCRIPTION
Potential fix for [https://github.com/axelmierczuk/tenrec/security/code-scanning/1](https://github.com/axelmierczuk/tenrec/security/code-scanning/1)

To fix this problem, add an explicit `permissions` block specifying the least privileges required for the job. For publishing to PyPI, the steps only need read access to repository contents, so the minimal setting is likely `contents: read`. You can add the `permissions` block at the workflow root, affecting all jobs within the workflow, or inside the specific job definition if only one job needs the setting. Since this workflow contains a single job, adding it at the root keeps it clean and obvious. To implement:  
- Edit `.github/workflows/publish.yml`.  
- Insert a `permissions:` block directly after the `name:` field and before `on:` (usually line 2), specifying `contents: read`.  
- No new imports or definitions are needed, as this is a config change.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
