### PR TITLE
Resolve TypeError in set_function_prototype by passing ea_t

### DIFF
--- a/tenrec/plugins/plugins/types.py
+++ b/tenrec/plugins/plugins/types.py
@@ -323,7 +323,7 @@ class TypesPlugin(PluginBase):
         :param prototype: The prototype
         :return:
         """
-        if not ida_bytes.is_loaded(function_address):
+        if not ida_bytes.is_loaded(function_address.ea_t):
             msg = f"Address {function_address} is not in a loaded segment"
             raise OperationError(msg)
         func = self.database.functions.get_at(function_address.ea_t)


### PR DESCRIPTION

## Summary

This PR fixes a `TypeError` occurring in the `set_function_prototype` function within the `types` plugin.

## Problem

When calling the `set_function_prototype` tool, the following error is triggered:

```text
● tenrec - types_set_function_prototype (MCP)
  ⎿  {                                                                
       "exception": "TypeError",
       "value": "in method 'is_loaded', argument 1 of type 'ea_t'"
     }

```

The error occurs because `ida_bytes.is_loaded` expects an `ea_t` type (an address), but the raw `function_address` object was being passed instead.

## Solution

Modified `set_function_prototype` to pass `function_address.ea_t` to the `ida_bytes.is_loaded` function. This aligns the implementation with the existing logic used in `set_global_variable_type` ([reference](https://github.com/axelmierczuk/tenrec/blob/687b2709efc2c0070fae5f91e8871549f6ba0369/tenrec/plugins/plugins/types.py#L348-L350)).
