### PR TITLE
Bump version to 1.0.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "tenrec"
-version = "1.0.0"
+version = "1.0.1"
 description = "A modern MCP server implementation for IDA Pro using ida-domain and FastMCP."
 readme = "README.md"
 license = {text = "MIT"}


### PR DESCRIPTION
## Summary
- Bump version from 1.0.0 to 1.0.1 for PyPI release

## Changes Included
This release includes changes from recently merged PRs:
- Local type filtering and refactor type listing with iterator helpers
- Fix function address check for loaded segments

## Release Process
After merging, create and push tag `v1.0.1` to trigger PyPI publish workflow.