### PR TITLE
docs: Restructure documentation with CLAUDE.md and agent_docs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,136 @@
+# Tenrec Development Guide
+
+Tenrec is a headless MCP framework for IDA Pro binary analysis, built with FastMCP and ida-domain.
+
+## Architecture Overview
+
+```
+tenrec/
+├── server.py                # MCP server, session management
+├── sessions.py              # Session wrapper (UUID, DatabaseHandler)
+├── plugins/
+│   ├── plugin_manager.py    # Plugin dispatch, tool registration
+│   ├── plugin_loader.py     # Entry point discovery
+│   ├── database_manager.py  # IDA database lifecycle
+│   ├── models/
+│   │   ├── base.py          # PluginBase, Instructions
+│   │   ├── operation.py     # @operation decorator
+│   │   ├── parameters.py    # PaginatedParameter, hooks
+│   │   └── ida.py           # HexEA, FunctionData models
+│   └── plugins/             # 9 built-in plugins
+├── management/              # CLI, config, environment
+└── tests/unit/              # Unit tests
+```
+
+See [agent_docs/architecture.md](agent_docs/architecture.md) for detailed architecture.
+
+## Code Style
+
+Configured in `ruff.toml`:
+
+- **Line length**: 120 characters
+- **Python**: 3.13 target
+- **Docstrings**: Google style
+- **Max complexity**: 10 (mccabe)
+- **Max args**: 6, **Max branches**: 12, **Max statements**: 50
+
+```bash
+ruff check .       # Lint
+ruff format .      # Format
+ruff check --fix . # Auto-fix
+```
+
+## Plugin Development
+
+Plugins inherit from `PluginBase` and use `@operation()` for MCP tools:
+
+```python
+from tenrec.plugins.models import PluginBase, Instructions, operation, HexEA
+
+class MyPlugin(PluginBase):
+    name = "my_plugin"           # Must be snake_case
+    version = "1.0.0"            # Must be semver
+    instructions = Instructions(
+        purpose="What this plugin does",
+        interaction_style=["How to use it"],
+        examples=["my_plugin_operation()"],
+        anti_examples=["What NOT to do"],
+    )
+
+    @operation()
+    def get_data(self, address: HexEA) -> dict:
+        """Get data at address."""
+        return self.database.functions.get_at(address)
+```
+
+Key points:
+
+- `self.database` is injected at runtime (ida-domain Database)
+- Use `HexEA` for addresses (ensures hex formatting)
+- Docstrings guide LLM understanding
+- `PaginatedParameter()` adds offset/limit to list operations
+
+See [agent_docs/plugin-development.md](agent_docs/plugin-development.md) for complete guide.
+
+## Testing
+
+Tests in `tenrec/tests/unit/` use mock fixtures:
+
+```python
+class TestMyPlugin:
+    @pytest.fixture
+    def plugin(self, mock_ida_database):
+        plugin = MyPlugin()
+        plugin.database = mock_ida_database
+        return plugin
+
+    @pytest.mark.unit
+    def test_operation(self, plugin):
+        result = plugin.get_data(address=0x401000)
+        assert result is not None
+```
+
+Key fixtures: `mock_ida_database`, `mock_database_handler`, `mock_function_data`
+
+```bash
+IDADIR="/path/to/ida" uv run pytest tenrec/tests/ -m unit
+```
+
+See [agent_docs/testing.md](agent_docs/testing.md) for patterns.
+
+## Common Tasks
+
+### Add a new plugin operation
+
+1. Add method to plugin class
+2. Decorate with `@operation()`
+3. Add docstring with `:param` and `:return:`
+4. Add unit tests
+
+### Add a new built-in plugin
+
+1. Create `tenrec/plugins/plugins/newplugin.py`
+2. Register in `pyproject.toml` entry points:
+   ```toml
+   [project.entry-points."tenrec.plugins"]
+   newplugin = "tenrec.plugins.plugins.newplugin:NewPlugin"
+   ```
+3. Add to `DEFAULT_PLUGINS` in `__init__.py`
+4. Add tests in `tenrec/tests/unit/test_newplugin_plugin.py`
+
+### Run the server locally
+
+```bash
+export IDADIR="/path/to/ida"
+tenrec run --transport sse
+```
+
+## Documentation
+
+- [Architecture](agent_docs/architecture.md) - System design
+- [Plugin Development](agent_docs/plugin-development.md) - Creating plugins
+- [CLI Reference](agent_docs/cli-reference.md) - Command reference
+- [Testing](agent_docs/testing.md) - Test patterns
+- [Contributing](agent_docs/contributing.md) - Contribution guidelines
+- [Integrations](agent_docs/integrations.md) - MCP client setup
+- [Roadmap](agent_docs/roadmap.md) - Future plans

--- a/README.md
+++ b/README.md
@@ -1,4 +1,3 @@
-
 <p align="center">
   <img alt="logo" src="https://raw.githubusercontent.com/axelmierczuk/tenrec/refs/heads/main/tenrec/documentation/static/_media/icon.svg" width="30%" height="30%">
 </p>
@@ -9,668 +8,170 @@
 [![Python Version](https://img.shields.io/pypi/pyversions/tenrec)](https://pypi.org/project/tenrec/)
 [![License](https://img.shields.io/pypi/l/tenrec)](https://img.shields.io/pypi/l/tenrec)
 
-A headless, extendable, multi-session, IDA Pro MCP framework built with [ida-domain](https://ida-domain.docs.hex-rays.com/)
-and FastMCP, inspired by [mrexodia/ida-pro-mcp](https://github.com/mrexodia/ida-pro-mcp). Supports custom plugins 
-for easy extension.
+A headless, extendable, multi-session MCP framework for IDA Pro, built with [ida-domain](https://ida-domain.docs.hex-rays.com/) and FastMCP.
 
-## Table of Contents
-- [Overview](#overview)
-- [Demo](#demo)
-- [Installation](#installation)
-- [Usage](#usage)
-  - [install / uninstall](#install--uninstall)
-  - [run](#run)
-  - [docs](#docs)
-  - [plugins](#plugins)
-- [Creating Custom Plugins](#creating-custom-plugins)
-- [Testing](#testing)
-- [Known Issues](#known-issues)
-- [Contributing](#contributing)
-- [Future Work](#future-work)
+## Features
 
-## Overview
+- **Headless**: No GUI required, powered by ida-domain
+- **Multi-session**: Analyze multiple binaries simultaneously
+- **Extensible**: Custom plugin support via entry points
+- **Auto-docs**: Generate documentation from plugins
 
-Tenrec aims to simplify the MCP experience with IDA Pro. Inspired by the existing IDA Pro plugin ecosystem and 
-[ida-pro-mcp](https://github.com/mrexodia/ida-pro-mcp), Tenrec provides a robust framework for building and using 
-plugins to automate and enhance reverse engineering tasks with LLMs.
+### Built-in Plugins
 
-Key features:
+| Plugin | Description |
+|--------|-------------|
+| Functions | Analyze functions, boundaries, pseudocode |
+| Xrefs | Data and code cross-references |
+| Names | Symbol naming and demangling |
+| Comments | Code comments (regular, repeatable) |
+| Strings | String literal search/analysis |
+| Segments | Memory segment queries |
+| Bytes | Binary data read/patch |
+| Types | Type information and structures |
+| Entries | Entry points and exports |
 
-- Completely headless IDA Pro interaction, made possible with ida-domain
-- Multi-session analysis, great when working with libraries used by an application
-- Custom plugin support
-- Auto-docs generation (including plugin docs)
+For complete plugin documentation, see [tenrec docs](https://axelmierczuk.github.io/tenrec/#/).
 
-Out-of-the box, Tenrec includes the following core plugins:
-
-- **Functions**: Analyze and manage functions, including boundaries, attributes, and pseudocode generation.
-- **Cross-References (Xrefs)**: Trace data and code cross-references throughout the binary.
-- **Names**: Manage symbol names, demangling, and naming conventions.
-- **Comments**: Add and retrieve various types of comments for documentation.
-- **Strings**: Search and analyze string literals in the binary.
-- **Segments**: Query memory segments and sections.
-- **Bytes**: Read and patch binary data at any address.
-- **Types**: Manage type information and data structures.
-- **Entries**: Access entry points and exported functions.
-
-For a complete breakdown of available plugins and their operations, check out the [documentation](https://axelmierczuk.github.io/tenrec/#/).
-
-> [!NOTE]  
-> For a list of community plugins, see the [tenrec-plugins](https://github.com/axelmierczuk/tenrec-plugins) repository.
+> [!NOTE]
+> Community plugins: [tenrec-plugins](https://github.com/axelmierczuk/tenrec-plugins)
 
 ## Demo
 
-Using tenrec and Claude Code, we were able to solve Challenge 4 from Flare-On 9 (darn mice) with a single prompt (see below).
-Find the complete challenge write-up [here](https://services.google.com/fh/files/misc/04-darn-mice.pdf). 
+Solving Flare-On 9 Challenge 4 (darn mice) with a single prompt using tenrec and Claude Code:
 
-To test this yourself, checkout the [fareedfauzi/Flare-On-Challenges](https://github.com/fareedfauzi/Flare-On-Challenges)
-repo for the binary and additional resources.
-
-
-> You have been provided with the binary called darn_mice.exe in the current directory. Use 
-tenrec to open a session and reverse the binary. Focus on getting a high-level 
-understanding of the application by finding entry points, and tracing execution flow. 
-Make sure to rename variables and functions as you work through the binary. The xref 
-plugin can be helpful in this task. You will ultimately be looking for a flag. The flag 
-is formatted in an email format, and may require decryption. Do not try to guess the 
-flag, use your analysis to guide you towards the correct answer based on the binary.
-
+> Use tenrec to open a session and reverse the binary. Focus on getting a high-level understanding by finding entry points and tracing execution flow. Rename variables and functions as you work. The xref plugin can help. Look for a flag in email format.
 
 https://github.com/user-attachments/assets/3eb442dd-9b7a-44a6-836b-b73f99f4c2f3
 
+Challenge write-up: [04-darn-mice.pdf](https://services.google.com/fh/files/misc/04-darn-mice.pdf) | Binary: [fareedfauzi/Flare-On-Challenges](https://github.com/fareedfauzi/Flare-On-Challenges)
 
 ## Installation
 
 ### Prerequisites
 
-- Python 3.10 or higher
-- IDA Pro 9.1+ installation
+- Python 3.10+
+- IDA Pro 9.1+
 
-### Install with uv 
+### Install
 
 ```bash
 uv tool install tenrec
 ```
 
-Confirm that tenrec is installed:
+Verify installation:
 
 ```bash
-# You should see tenrec in the list of installed tools
-uv tool list 
-# Which tenrec should show the path to the tenrec executable
-which tenrec
+uv tool list    # Should show tenrec
+which tenrec    # Should show path to executable
 ```
 
-Since tenrec depends on `ida-domain`, you need to set the `IDADIR` environment variable to point to your IDA Pro 
-installation directory before running tenrec commands. For example:
+### Set IDA Directory
 
 ```bash
-# macOS example
+# macOS
 export IDADIR="/Applications/IDA Professional 9.1.app/Contents/MacOS"
-# Linux example  
-export IDADIR="/opt/idapro"  
-# Windows example (PowerShell, run as Administrator)
-setx IDADIR "C:\Program Files\IDA Pro" /M  
+
+# Linux
+export IDADIR="/opt/idapro"
+
+# Windows (PowerShell, as Administrator)
+setx IDADIR "C:\Program Files\IDA Pro" /M
 ```
 
-### Development Installation
+## Quick Start
 
-```bash
-# Clone the repository
-git clone https://github.com/axelmierczuk/tenrec.git
-cd tenrec
-
-# Install in development mode with dependencies
-uv pip install -e ".[dev]"
-```
-
-## Usage
-
-### install / uninstall
-
-After installing tenrec, you can install or uninstall the MCP server with a variety of MCP clients.
-
-Currently, the following clients are supported:
-
-- [CLine](https://cline.bot/)
-- [Roo Code](https://github.com/RooCodeInc/Roo-Code)
-- [Kilo Code](https://kilocode.ai/)
-- [Claude](https://claude.ai/download)
-- [Cursor](https://cursor.com/en)
-- [Windsurf](https://windsurf.com/)
-- [Claude Code](https://www.anthropic.com/claude-code)
-- [LM Studio](https://lmstudio.ai/)
-
-Additional clients like [Cortex](https://github.com/openai/codex) can be used as well, but require manual installation at the moment.
-
-Get started with the install command:
+### 1. Install MCP Client
 
 ```bash
 tenrec install
 ```
 
-<details>
+Select your MCP client from the list (Claude Code, Cursor, Windsurf, etc.).
 
-<summary><b>Install / uninstall command help menus</b></summary>
-
-```
- Usage: tenrec install [OPTIONS]
-
- Install tenrec with MCP clients.
-
-╭─ Options ────────────────────────────────────────────────────────────────────────────────╮
-│ --help      Show this message and exit.                                                  │
-╰──────────────────────────────────────────────────────────────────────────────────────────╯
-```
-
-
-```
- Usage: tenrec uninstall [OPTIONS]
-
- Uninstall tenrec and MCP clients.
-
-╭─ Options ────────────────────────────────────────────────────────────────────────────────╮
-│ --help      Show this message and exit.                                                  │
-╰──────────────────────────────────────────────────────────────────────────────────────────╯
-```
-
-</details>
-
-<details>
-<summary><b>Manual installation for Codex</b></summary>
-
-
-tenrec can also be used with other LLM clients like Codex, even if these are not yet supported by the `install` command.
-
-The following step by step installation guide shows how to use Codex with tenrec and the GPT4.1 LLM via AzureAI and API key authentication on Linux. [Azure OpenAI in Codex](https://devblogs.microsoft.com/all-things-azure/codex-azure-openai-integration-fast-secure-code-development/). Please note that AzureAI API keys are different from OpenAI API keys. Ensure that you deployed your AzureID resource in one of the supported regions for [Responses API](https://learn.microsoft.com/en-us/azure/ai-foundry/openai/how-to/responses?tabs=python-secure#region-availability)
-
-
-In order to use tenrec with Codex proceed as follows:
-
-  * Download the latest Codex release from https://github.com/openai/codex/releases (We're using 0.39.0 in the Linux x86_64-unknown-gnu.tar.gz version)
-  * Unpack at the place of your choice with: `tar --zstd -xvf codex-x86_64-unknown-linux-gnu.tar.gz`
-  * Make it executable via: `chmod +x codex-x86_64-unknown-lunux`
-  * Deploy the GPT-4.1 model in your Azure OpenAI workspace:
-    
-    See https://learn.microsoft.com/en-us/azure/ai-foundry/openai/how-to/create-resource?pivots=web-portal for details. Make sure you are using a supported region for the [Responses API](https://learn.microsoft.com/en-us/azure/ai-foundry/openai/how-to/responses?tabs=python-secure#region-availability)
-
-  * Create the codex configuration file in `~/.codex/config.toml` with the following content
-
-    ```
-    # Set the default model and provider
-    model = "gpt-4.1" 
-    model_provider = "azure"
-    preferred_auth_method = "apikey"
-
-    # Configure the Azure provider
-    [model_providers.azure]
-    name = "Azure"
-    # Make sure you set the appropriate subdomain for this URL.
-    base_url = "https://<your_azure_ai_deployment>.openai.azure.com/openai"
-    env_key = "AZURE_OPENAI_API_KEY"
-    query_params = { api-version = "2025-04-01-preview" }
-    wire_api = "responses"
-    model_reasoning_effort = "high"
-
-    [projects."/tmp"]
-    trust_level = "trusted"
-
-    [mcp_servers.tenrec]
-    command = "uvx"
-    args = ["tenrec", "run"]
-    env = { "IDADIR"="/home/user/ida-essential-9.2" }
-
-
-  * Set the environment variable AZURE_OPENAI_API_KEY
-
-    You will find the API Key in the Azure AIFoundry Overview page for your deployed resource.
-
-    `export AZURE_OPENAI_API_KEY=xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx`
-
-    The exported variable must match the name for `env_key` in the config.toml file.
-
-    Keep this API key secret.
-
-  * Test it
-
-    `codex-x86_64-unknown-linux "Write me a Haiku"`
-    ```
-
-    ╭────────────────────────────────────────────────────────╮
-    │ >_ OpenAI Codex (v0.39.0)                              │
-    │                                                        │
-    │ model:     gpt-4.1   /model to change                  │
-    │ directory: /tmp                                        │
-    ╰────────────────────────────────────────────────────────╯
-
-      To get started, describe a task or try one of these commands:
-
-      /init - create an AGENTS.md file with instructions for Codex
-      /status - show current session configuration
-      /approvals - choose what Codex can do without approval
-      /model - choose what model and reasoning effort to use
-
-    ▌ Write me a Haiku
-
-    > Gentle morning light
-      Whispers through the waking trees
-      Hope blooms with the dawn
-
-    ▌ Find and fix a bug in @filename                                                                                                                                            
-
-    ⏎ send   Ctrl+J newline   Ctrl+T transcript   Ctrl+C quit   14.0K tokens used   99% context left                                                                             
-    ```
-
-    If you receive a response without error, Codex has been setup correctly with AzureAI.
-
-  * Test tenrec in Codex
-
-    Use codex with the same demo prompt above. Copy darn_mice.exe to /tmp and run
-
-    `codex "You have been provided with the binary called darn_mice.exe in the /tmp directory. Use 
-tenrec to open a session and reverse the binary. Focus on getting a high-level 
-understanding of the application by finding entry points, and tracing execution flow. 
-Make sure to rename variables and functions as you work through the binary. The xref 
-plugin can be helpful in this task. You will ultimately be looking for a flag. The flag 
-is formatted in an email format, and may require decryption. Do not try to guess the 
-flag, use your analysis to guide you towards the correct answer based on the binary."`
-
- 
-</details>
-
-### run
-
-Run the tenrec MCP server! 
-
-By default, tenrec loads built-in plugins and ones stored in the config.
-If you want to disable loading the config or built-in plugins, use the `--no-config` or `--no-default-plugins` flags.
-Additional plugins can be specified with the `-p` / `--plugin` argument.
+### 2. Run Server
 
 ```bash
-tenrec run --transport sse
+tenrec run
 ```
 
-<details>
+The server runs with stdio transport by default. Use `--transport sse` for SSE.
 
-<summary><b>Run command help menu</b></summary>
-
-```
- Usage: tenrec run [OPTIONS]
-
- Run the tenrec server.
-
-╭─ Options ────────────────────────────────────────────────────────────────────────────────╮
-│ --no-config                                               If set, the configuration file │
-│                                                           will not be used to load       │
-│                                                           plugins.                       │
-│ --no-default-plugins                                      If set, default plugins will   │
-│                                                           not be loaded.                 │
-│ --transport           -t  [stdio|http|sse|streamable-htt  Transport type to use for      │
-│                           p]                              communication (default: stdio) │
-│ --plugin              -p  TEXT                            Plugin to load. Could be a     │
-│                                                           PyPI package name, local path, │
-│                                                           or git repo.                   │
-│ --help                                                    Show this message and exit.    │
-╰──────────────────────────────────────────────────────────────────────────────────────────╯
-
-```
-
-</details>
-
-### plugins
-
-Tenrec supports a plugin system that allows you to extend its functionality with custom plugins.
-
-Adding plugins is made simple by specifying a package name that uv can process. For example, this can be a package
-that can be found on pypi, a git repo, or on the filesystem. Under the hood, tenrec uses uv to install plugins,
-so you can use any format supported by uv ([Astral - Managing Packages](https://docs.astral.sh/uv/pip/packages/#managing-packages)). 
-
-#### Examples
+### 3. Plugin Management
 
 ```bash
-tenrec plugins add --plugin "example-package"       # Install from PyPI
-tenrec plugins add --plugin "/path/to/local/plugin" # Install from local path
-tenrec plugins add --plugin \                       # Install from git repo
-  "git+ssh://git@github.com/axelmierczuk/tenrec#subdirectory=examples"
-```
+# Add plugin
+tenrec plugins add --plugin "package-name"
+tenrec plugins add --plugin "/path/to/plugin"
+tenrec plugins add --plugin "git+https://github.com/user/repo"
 
-```bash
-# Install from git repo
-tenrec plugins add --plugin \
-  "git+ssh://git@github.com/axelmierczuk/tenrec#subdirectory=examples"
-# List installed plugins
+# List plugins
 tenrec plugins list
-# Remove a plugin by dist name
-tenrec plugins remove --dist example_plugin
+
+# Remove plugin
+tenrec plugins remove --dist plugin_name
 ```
 
-<details>
-
-<summary><b>Plugins command help menus</b></summary>
-
-```
- Usage: tenrec plugins [OPTIONS] COMMAND [ARGS]...
-
- Manage tenrec plugins.
-
-╭─ Options ────────────────────────────────────────────────────────────────────────────────╮
-│ --help      Show this message and exit.                                                  │
-╰──────────────────────────────────────────────────────────────────────────────────────────╯
-╭─ Commands ───────────────────────────────────────────────────────────────────────────────╮
-│ add                 Add a new plugin.                                                    │
-│ list                List installed plugins.                                              │
-│ remove              Remove an existing plugin.                                           │
-╰──────────────────────────────────────────────────────────────────────────────────────────╯
-```
-
-```
- Usage: tenrec plugins add [OPTIONS]
-
- Add a new plugin.
-
-╭─ Options ────────────────────────────────────────────────────────────────────────────────╮
-│ *  --plugin  -p  TEXT  Plugin to load. Could be a PyPI package name, local path, or git  │
-│                        repo.                                                             │
-│                        [required]                                                        │
-│    --help              Show this message and exit.                                       │
-╰──────────────────────────────────────────────────────────────────────────────────────────╯
-```
-
-```
- Usage: tenrec plugins list [OPTIONS]
-
- List installed plugins.
-
-╭─ Options ────────────────────────────────────────────────────────────────────────────────╮
-│ --help      Show this message and exit.                                                  │
-╰──────────────────────────────────────────────────────────────────────────────────────────╯
-```
-
-```
- Usage: tenrec plugins remove [OPTIONS]
-
- Remove an existing plugin.
-
-╭─ Options ────────────────────────────────────────────────────────────────────────────────╮
-│ *  --dist  -d  TEXT  Plugin dists(s) to remove from the configuration [required]         │
-│    --help            Show this message and exit.                                         │
-╰──────────────────────────────────────────────────────────────────────────────────────────╯
-```
-
-</details>
-
-### docs
-
-The `docs` command generates documentation for your plugins and operations using [docsify](https://docsify.js.org/). 
-This allows you to create self-documenting plugins that are easy to understand and use. 
-
-Using the `-p` / `--plugin` argument, you can specify one or more plugins to include in the documentation. 
-Since the server implements session management as core functionality, it will automatically be included in your 
-documentation.
-
-Not happy with the default homepage? You can specify a custom README file with the `-r` / `--readme` argument.
+### 4. Generate Documentation
 
 ```bash
-git clone git@github.com:axelmierczuk/tenrec.git
-cd tenrec
 tenrec docs -p tenrec/plugins/plugins
 ```
 
-<details>
+## Documentation
 
-<summary><b>Docs command help menu</b></summary>
+| Guide | Description |
+|-------|-------------|
+| [Plugin Development](agent_docs/plugin-development.md) | Creating custom plugins |
+| [CLI Reference](agent_docs/cli-reference.md) | Complete command reference |
+| [Architecture](agent_docs/architecture.md) | System design |
+| [Testing](agent_docs/testing.md) | Testing patterns |
+| [Integrations](agent_docs/integrations.md) | MCP client setup (including Codex) |
+| [Contributing](agent_docs/contributing.md) | Development setup and guidelines |
+| [Roadmap](agent_docs/roadmap.md) | Future plans |
 
-```
- Usage: tenrec docs [OPTIONS]
-
- Generate documentation.
-
-╭─ Options ────────────────────────────────────────────────────────────────────────────────╮
-│    --output     -o  DIRECTORY  Output directory for the generated documentation.         │
-│                                [default: docs]                                           │
-│    --readme         PATH       Path to a README file to include in the documentation.    │
-│    --base-path      TEXT       The base path for the URL.                                │
-│    --repo           TEXT       The URL of the repository for the project.                │
-│    --name           TEXT       Name of the documentation set. [default: tenrec]          │
-│ *  --plugin     -p  TEXT       Plugin to load. Could be a PyPI package name, local path, │
-│                                or git repo.                                              │
-│                                [required]                                                │
-│    --help                      Show this message and exit.                               │
-╰──────────────────────────────────────────────────────────────────────────────────────────╯
-```
-
-</details>
-
-## Creating Custom Plugins
-
-Extend Tenrec with your own plugins!
-
-Simply build a class inheriting from `PluginBase` and define operations.
-
-There are a few important things to note:
-
-- **Name**
-  - The `name` attribute must be in `snake_case` format. This name will be pre-pended to all operation names to avoid conflicts.
-- **Description**
-  - The class docstring will be used as the plugin description in the documentation.
-- **Instructions**
-  - The `instructions` attribute helps LLMs understand the purpose and usage of your plugin.
-- **Operations**
-  - Each operation must be decorated with the `@operation()` decorator. You can have other methods in your class, but only decorated methods will be exposed as operations.
-  - The docstrings of the operations will be used by the model to understand what the operation does. Be accurate with your parameters and return types.
-- **Parameters / Return Types**
-  - When working with addresses, use the [`HexEA`](tenrec/plugins/models/ida.py) model if possible. This class ensures that addresses are always 
-represented in hexadecimal format, which is more familiar to reverse engineers and the LLMs. It also integrates directly with 
-the `ida-domain` database APIs. Import it with:
-
-    ```python
-    from tenrec.plugins.models import HexEA
-    ```
-  - Use standard Python types (e.g., `int`, `str`, `list`, `dict`) or Pydantic models for parameters and return types. 
-
-
-Once your plugin is defined, create a `pyproject.toml` file to package it, making sure to include:
-
-```toml
-[project.entry-points."tenrec.plugins"]
-plugin = "file:ClassName" # Specify the path to your plugin class
-``` 
-
-A more complex example can be found in [examples](examples).
-
-<details>
-
-<summary><b>Example plugin</b></summary>
+## Creating Plugins
 
 ```python
 from tenrec.plugins.models import PluginBase, Instructions, operation
 
-class CustomAnalysisPlugin(PluginBase):
-    """This docstring will be used as the description of your plugin when documenting!"""
-    
-    name = "must_be_snake_case"
-    version = "1.0.0"
-    
-    # Instructions help LLMs understand the purpose and usage of your plugin
+class MyPlugin(PluginBase):
+    """Plugin description."""
+
+    name = "my_plugin"  # Must be snake_case
+    version = "1.0.0"   # Must be semver
+
     instructions = Instructions(
-        purpose="Perform custom binary analysis operations",
-        interaction_style=[
-            "You can call operations like find_crypto() or detect_packer() to analyze the binary."
-        ],
-        examples=[
-            "Find cryptographic constants: custom_analysis_find_crypto()",
-            "Detect packers: custom_analysis_detect_packer()"
-        ],
-        anti_examples=[
-            "Some anti examples",
-        ]
+        purpose="What this plugin does",
+        interaction_style=["How to use effectively"],
+        examples=["my_plugin_operation()"],
+        anti_examples=["What NOT to do"],
     )
-    
+
     @operation()
-    def find_crypto(self) -> list[dict]:
-        """Find potential cryptographic constants in the binary."""
-        results = []
-        # Your analysis logic here using self.database, which is provided to you by PluginBase
-        # When switching to a different database/session, this will be updated automatically
-        for ea in self.database.functions.get_all():
-            # Check for crypto patterns
-            pass
-        return results
-    
-    @operation()
-    def detect_packer(self) -> dict:
-        """Detect if the binary is packed."""
-        # Packer detection logic
-        return {"packed": False, "packer": None}
-
-```
-</details>
-
-### Creating Custom Operation Parameters
-
-If you find yourself needing to add the same arguments to many of your operations, you can define custom operation parameters
-(see [tenrec/plugins/models/parameters.py](tenrec/plugins/models/parameters.py) for the implementation details of `PaginatedParameter`).
-
-Custom operations must implement four methods:
-
-- `hook_apply_signature`
-- `hook_apply_annotations`
-- `hook_pre_call`
-- `hook_post_call`
-
-### hook_apply_signature
-
-
-```python
-hook_apply_signature(self, signature: inspect.Signature) -> inspect.Signature
+    def my_operation(self) -> dict:
+        """Operation docstring for LLM guidance."""
+        # Access IDA via self.database
+        return {"result": "value"}
 ```
 
+Package with entry point in `pyproject.toml`:
 
-The `hook_apply_signature` hook allows for modification of the operation signature. 
-You can add or remove parameters, change their types, or modify the return type. In the `PaginatedParameter`, 
-we use this hook to add `offset` and `limit` parameters to the operation signature. 
-
-### hook_apply_annotations
-
-```python
-hook_apply_annotations(self, annotations: dict) -> dict
+```toml
+[project.entry-points."tenrec.plugins"]
+my_plugin = "my_package:MyPlugin"
 ```
 
-
-The `hook_apply_annotations` hook allows for modification of the operation annotations.
-In the `PaginatedParameter`, we use this hook to update the return type annotation to reflect the pagination.
-
-### hook_pre_call
-
-```python
-hook_pre_call(self, context: dict, *args, **kwargs) -> tuple[tuple, dict]
-```
-
-The `hook_pre_call` hook allows for modification of the operation arguments before the call to the operation.
-In the `PaginatedParameter`, we use this hook to pop the `offset` and `limit` parameters from the arguments into 
-the context that is passed to the operation. 
-
-### hook_post_call
-
-```python
-hook_post_call(self, context: dict, result: Any) -> Any
-```
-
-The `hook_post_call` hook allows for modification of the operation result after the call to the operation.
-In the `PaginatedParameter`, we use this hook to slice the result based on the `offset` and `limit` values from the context.
-
-
-## Testing
-
-Tenrec includes a comprehensive test suite. Run tests with pytest:
-
-```bash
-# Run all tests
-IDADIR="/path/to/ida" uv run pytest tenrec/tests/
-
-# Run specific test module
-IDADIR="/path/to/ida" uv run pytest tenrec/tests/unit/test_functions_plugin.py
-
-# Run with coverage report
-IDADIR="/path/to/ida" uv run pytest tenrec/tests/ --cov=tenrec --cov-report=html
-
-# Run tests with verbose output
-IDADIR="/path/to/ida" uv run pytest tenrec/tests/ -v
-```
-
-### Writing Tests
-
-Create unit tests for your custom plugins:
-
-```python
-import pytest
-from unittest.mock import MagicMock
-from my_plugins import CustomAnalysisPlugin
-
-class TestCustomAnalysisPlugin:
-    @pytest.fixture
-    def plugin(self):
-        plugin = CustomAnalysisPlugin()
-        plugin.db = MagicMock()
-        return plugin
-    
-    def test_find_crypto(self, plugin):
-        # Mock IDA database calls
-        plugin.db.functions.get_all.return_value = [0x401000, 0x402000]
-        
-        # Test the operation
-        results = plugin.find_crypto()
-        assert isinstance(results, list)
-```
-
+See [Plugin Development Guide](agent_docs/plugin-development.md) for complete documentation.
 
 ## Known Issues
-- Tenrec is currently not supported on Windows. Work to enable this is ongoing. See [Issue #9](https://github.com/axelmierczuk/tenrec/issues/9) for details.
+
+- Windows support is in progress. See [Issue #9](https://github.com/axelmierczuk/tenrec/issues/9).
 
 ## Contributing
 
-We welcome contributions! Please follow these guidelines:
+See [Contributing Guide](agent_docs/contributing.md) for development setup and guidelines.
 
-### Development Setup
+## License
 
-1. Fork the repository
-2. Create a feature branch (`git checkout -b feature/amazing-feature`)
-3. Make your changes
-4. Run tests and linting
-5. Commit your changes (`git commit -m 'Add amazing feature'`)
-6. Push to the branch (`git push origin feature/amazing-feature`)
-7. Open a Pull Request
-
-### Code Style
-
-We use `ruff` for linting and formatting:
-
-```bash
-# Check code style
-ruff check .
-
-# Format code
-ruff format .
-
-# Fix common issues
-ruff check --fix .
-```
-
-### Commit Guidelines
-
-- Use clear, descriptive commit messages
-- Reference issues when applicable
-- Keep commits focused and atomic
-
-## Future Work
-
-- **Enhanced Plugin System**: Dynamic plugin loading and hot-reload support
-- **Performance Optimizations**: Caching and batch operations
-- **Additional Plugins Ideas**: 
-  - Vulnerability detection
-  - Binary diffing
-  - Automated unpacking
-  - Machine learning-based analysis
-- **Integration Improvements**: Better integration with other reverse engineering tools
-- **Documentation**: Expanded API documentation and tutorials
-
+MIT

--- a/agent_docs/architecture.md
+++ b/agent_docs/architecture.md
@@ -1,0 +1,175 @@
+# Tenrec Architecture
+
+This document describes the internal architecture of tenrec, a headless MCP framework for IDA Pro binary analysis.
+
+## System Overview
+
+Tenrec bridges IDA Pro's binary analysis capabilities with AI/LLM workflows through the Model Context Protocol (MCP). The system operates entirely headless using the `ida-domain` SDK.
+
+```
+┌─────────────┐     ┌──────────────┐     ┌─────────────┐
+│  MCP Client │────▶│ Tenrec Server│────▶│  IDA Domain │
+│ (Claude, etc)│◀────│  (FastMCP)   │◀────│  (Headless) │
+└─────────────┘     └──────────────┘     └─────────────┘
+        │                  │
+        │                  ▼
+        │           ┌──────────────┐
+        │           │   Plugins    │
+        │           │ (9 built-in) │
+        │           └──────────────┘
+        │                  │
+        └──────────────────┘
+              MCP Tools
+```
+
+## Core Components
+
+### Server (`tenrec/server.py`)
+
+The central orchestrator that:
+
+- Manages multiple IDA Pro sessions (dict of `Session` objects)
+- Coordinates plugin registration with FastMCP
+- Exposes session operations: `new_session()`, `list_sessions()`, `set_session()`, `remove_session()`, `remove_all_sessions()`
+- Applies IDA monkey patches for compatibility (e.g., `StringType.__str__`)
+
+### Session (`tenrec/sessions.py`)
+
+Session wrapper that:
+
+- Uniquely identified by UUID
+- Wraps `DatabaseHandler` for each binary
+- Tracks file path, IDA options, and database status
+
+### DatabaseHandler (`tenrec/plugins/database_manager.py`)
+
+Thread-safe database lifecycle manager:
+
+- Wraps `ida_domain.Database`
+- Manages open/close with proper analysis flags
+- Tracks status: `WAITING → OPENING → READY → CLOSING → CLOSED`
+- Handles save/load of IDA database files (`.i64`, `.idb`)
+
+### Plugin System
+
+#### PluginBase (`tenrec/plugins/models/base.py`)
+
+Abstract base class for all plugins:
+
+```python
+class PluginBase:
+    database: Database  # Injected at runtime
+    name: str           # Must be snake_case
+    version: str        # Must be semver (X.Y.Z)
+    instructions: Instructions
+```
+
+Validation is enforced in `__new__`:
+- `name` must be a valid snake_case identifier
+- `version` must follow semantic versioning
+
+#### Operation Decorator (`tenrec/plugins/models/operation.py`)
+
+Marks methods as MCP-exposed tools:
+
+```python
+@operation(options=[PaginatedParameter()])
+def get_all_functions(self) -> list[FunctionData]:
+    ...
+```
+
+- Attached to plugin methods
+- Supports custom parameter options (e.g., `PaginatedParameter`)
+- Transforms signatures/return types for MCP compatibility
+
+#### PluginManager (`tenrec/plugins/plugin_manager.py`)
+
+Central dispatcher that:
+
+- Introspects plugins for `@operation()` decorated methods
+- Creates MCP-compatible tool wrappers via dispatcher pattern
+- Injects database references into plugin instances
+- Handles pre/post-call hooks for custom operation parameters
+- Returns standardized error dicts on exceptions: `{"exception": type(e).__name__, "value": str(e)}`
+
+#### PluginLoader (`tenrec/plugins/plugin_loader.py`)
+
+Dynamic plugin discovery:
+
+- Uses setuptools entry points: `tenrec.plugins` group
+- Supports loading from PyPI, git repos, or local paths
+
+## Directory Structure
+
+```
+tenrec/
+├── __main__.py              # Entry point, logger config
+├── entrypoint.py            # CLI setup (rich-click)
+├── server.py                # Main MCP server, session management
+├── sessions.py              # Session class
+├── plugins/
+│   ├── plugin_manager.py    # Discovers & dispatches plugin operations
+│   ├── plugin_loader.py     # Entry point discovery
+│   ├── database_manager.py  # IDA database lifecycle
+│   ├── models/
+│   │   ├── base.py          # PluginBase class with validation
+│   │   ├── exceptions.py    # OperationError
+│   │   ├── operation.py     # @operation decorator
+│   │   ├── parameters.py    # PaginatedParameter & parameter hooks
+│   │   └── ida.py           # IDA data models (HexEA, FunctionData)
+│   └── plugins/             # Built-in plugins (9)
+│       ├── functions.py
+│       ├── xrefs.py
+│       ├── names.py
+│       ├── comments.py
+│       ├── strings.py
+│       ├── segments.py
+│       ├── bytes.py
+│       ├── types.py
+│       └── entries.py
+├── management/              # CLI and configuration
+│   ├── environment.py       # Environment variable handling
+│   ├── config.py            # Plugin configuration management
+│   ├── venv.py              # Virtual environment management
+│   └── options.py           # CLI option decorators
+├── documentation/           # Auto-doc generation (Docsify)
+└── tests/
+    └── unit/                # Unit tests
+```
+
+## Data Flow
+
+1. **Client Connection**: MCP client connects via configured transport (stdio, HTTP, SSE, streamable-HTTP)
+2. **Session Creation**: Client calls `new_session(path)` to open an IDA database
+3. **Tool Invocation**: Client calls plugin operation (e.g., `functions_get_all`)
+4. **Plugin Dispatch**: PluginManager routes to appropriate plugin method
+5. **Database Access**: Plugin uses `self.database` (ida-domain) to query IDA
+6. **Result Return**: Results serialized and returned via MCP
+
+## Built-in Plugins
+
+| Plugin | Purpose |
+|--------|---------|
+| `functions` | Function analysis, pseudocode, boundaries |
+| `xrefs` | Data/code cross-references |
+| `names` | Symbol naming, demangling, renaming |
+| `comments` | Code comments (regular, repeatable, etc.) |
+| `strings` | String literal search/analysis |
+| `segments` | Memory segment queries |
+| `bytes` | Binary data read/patch |
+| `types` | Type information & data structures |
+| `entries` | Entry points & exported functions |
+
+## Session Management
+
+- Each binary gets a unique UUID session
+- Only one session can be "active" at a time
+- Previous session auto-closed when switching
+- Supports concurrent database management via threading
+
+## MCP Integration
+
+- FastMCP server exposes all plugin operations as tools
+- Tool naming convention: `{plugin_name}_{method_name}`
+- Instructions auto-generated from plugin `Instructions` model
+- Supports multiple transports: stdio, HTTP, SSE, streamable-HTTP

--- a/agent_docs/cli-reference.md
+++ b/agent_docs/cli-reference.md
@@ -1,0 +1,253 @@
+# CLI Reference
+
+Complete reference for all tenrec CLI commands.
+
+## Global Options
+
+All commands support:
+
+- `--help`: Show help message and exit
+
+## tenrec install
+
+Install tenrec with MCP clients.
+
+```
+Usage: tenrec install [OPTIONS]
+
+Install tenrec with MCP clients.
+
+Options:
+  --help    Show this message and exit.
+```
+
+Supported clients:
+
+- CLine
+- Roo Code
+- Kilo Code
+- Claude Desktop
+- Cursor
+- Windsurf
+- Claude Code
+- LM Studio
+
+The installer will prompt you to select which clients to configure.
+
+## tenrec uninstall
+
+Remove tenrec from MCP clients.
+
+```
+Usage: tenrec uninstall [OPTIONS]
+
+Uninstall tenrec and MCP clients.
+
+Options:
+  --help    Show this message and exit.
+```
+
+## tenrec run
+
+Start the tenrec MCP server.
+
+```
+Usage: tenrec run [OPTIONS]
+
+Run the tenrec server.
+
+Options:
+  --no-config                        Do not load plugins from configuration file
+  --no-default-plugins               Do not load built-in plugins
+  -t, --transport [stdio|http|sse|streamable-http]
+                                     Transport type (default: stdio)
+  -p, --plugin TEXT                  Additional plugin to load (repeatable)
+  --help                             Show this message and exit.
+```
+
+### Transport Options
+
+| Transport | Description | Use Case |
+|-----------|-------------|----------|
+| `stdio` | Standard input/output | Default for most MCP clients |
+| `http` | HTTP server | REST-style integration |
+| `sse` | Server-sent events | Real-time streaming |
+| `streamable-http` | Streamable HTTP | Large response streaming |
+
+### Examples
+
+```bash
+# Run with default settings (stdio transport, all plugins)
+tenrec run
+
+# Run with SSE transport
+tenrec run --transport sse
+
+# Run without built-in plugins
+tenrec run --no-default-plugins
+
+# Load additional plugin from PyPI
+tenrec run --plugin "tenrec-crypto-plugin"
+
+# Load plugin from local path
+tenrec run --plugin "/path/to/my/plugin"
+
+# Load plugin from git repo
+tenrec run --plugin "git+https://github.com/user/plugin"
+
+# Combine options
+tenrec run -t sse -p "plugin1" -p "plugin2" --no-config
+```
+
+## tenrec plugins
+
+Manage tenrec plugins.
+
+```
+Usage: tenrec plugins [OPTIONS] COMMAND [ARGS]...
+
+Manage tenrec plugins.
+
+Options:
+  --help    Show this message and exit.
+
+Commands:
+  add       Add a new plugin.
+  list      List installed plugins.
+  remove    Remove an existing plugin.
+```
+
+### tenrec plugins add
+
+Add a plugin to the configuration.
+
+```
+Usage: tenrec plugins add [OPTIONS]
+
+Add a new plugin.
+
+Options:
+  -p, --plugin TEXT    Plugin to load (PyPI, local path, or git repo) [required]
+  --help               Show this message and exit.
+```
+
+Plugin sources:
+
+- **PyPI**: Package name (e.g., `tenrec-crypto-plugin`)
+- **Local path**: Absolute or relative path (e.g., `/path/to/plugin`)
+- **Git repo**: Git URL (e.g., `git+https://github.com/user/repo`)
+  - With subdirectory: `git+https://github.com/user/repo#subdirectory=plugins/myplugin`
+
+### tenrec plugins list
+
+Show configured plugins.
+
+```
+Usage: tenrec plugins list [OPTIONS]
+
+List installed plugins.
+
+Options:
+  --help    Show this message and exit.
+```
+
+### tenrec plugins remove
+
+Remove a plugin from configuration.
+
+```
+Usage: tenrec plugins remove [OPTIONS]
+
+Remove an existing plugin.
+
+Options:
+  -d, --dist TEXT    Plugin distribution name(s) to remove [required]
+  --help             Show this message and exit.
+```
+
+### Examples
+
+```bash
+# Add plugin from PyPI
+tenrec plugins add --plugin "example-package"
+
+# Add plugin from local path
+tenrec plugins add --plugin "/path/to/local/plugin"
+
+# Add plugin from git repo with subdirectory
+tenrec plugins add --plugin \
+  "git+ssh://git@github.com/axelmierczuk/tenrec#subdirectory=examples"
+
+# List all configured plugins
+tenrec plugins list
+
+# Remove a plugin by distribution name
+tenrec plugins remove --dist example_plugin
+```
+
+## tenrec docs
+
+Generate documentation for plugins.
+
+```
+Usage: tenrec docs [OPTIONS]
+
+Generate documentation.
+
+Options:
+  -o, --output DIRECTORY    Output directory (default: docs)
+  --readme PATH             Custom README file for homepage
+  --base-path TEXT          Base path for URLs
+  --repo TEXT               Repository URL for project
+  --name TEXT               Documentation name (default: tenrec)
+  -p, --plugin TEXT         Plugin to document [required]
+  --help                    Show this message and exit.
+```
+
+Documentation is generated using [Docsify](https://docsify.js.org/) and includes:
+
+- Plugin descriptions
+- Operation signatures and docstrings
+- Instructions for LLM usage
+- Session management tools
+
+### Examples
+
+```bash
+# Generate docs for built-in plugins
+tenrec docs -p tenrec/plugins/plugins
+
+# Generate docs with custom output directory
+tenrec docs -p my_plugin -o ./documentation
+
+# Generate docs with custom README
+tenrec docs -p my_plugin --readme ./CUSTOM_README.md
+
+# Generate docs for multiple plugins
+tenrec docs -p plugin1 -p plugin2 -p plugin3
+```
+
+## Environment Variables
+
+### IDADIR (Required)
+
+Path to IDA Pro installation directory.
+
+```bash
+# macOS
+export IDADIR="/Applications/IDA Professional 9.1.app/Contents/MacOS"
+
+# Linux
+export IDADIR="/opt/idapro"
+
+# Windows (PowerShell, run as Administrator)
+setx IDADIR "C:\Program Files\IDA Pro" /M
+```
+
+### TENREC_DEBUG (Optional)
+
+Enable debug logging.
+
+```bash
+export TENREC_DEBUG=1
+```

--- a/agent_docs/contributing.md
+++ b/agent_docs/contributing.md
@@ -1,0 +1,188 @@
+# Contributing to Tenrec
+
+Guidelines for contributing to the tenrec project.
+
+## Development Setup
+
+### Prerequisites
+
+- Python 3.10 or higher
+- IDA Pro 9.1+ installation
+- `uv` package manager
+
+### Clone and Install
+
+```bash
+# Clone the repository
+git clone https://github.com/axelmierczuk/tenrec.git
+cd tenrec
+
+# Install in development mode with dependencies
+uv pip install -e ".[dev]"
+```
+
+### Set Environment
+
+```bash
+# Set IDA directory (required)
+export IDADIR="/path/to/ida"
+```
+
+## Code Style
+
+Tenrec uses `ruff` for linting and formatting. Configuration is in `ruff.toml`.
+
+### Key Settings
+
+| Setting | Value |
+|---------|-------|
+| Line length | 120 characters |
+| Target Python | 3.13 |
+| Docstring style | Google |
+| Max complexity | 10 (mccabe) |
+| Max function args | 6 |
+| Max branches | 12 |
+| Max statements | 50 |
+
+### Running Linters
+
+```bash
+# Check code style
+ruff check .
+
+# Format code
+ruff format .
+
+# Fix common issues
+ruff check --fix .
+```
+
+### Type Annotations
+
+- All public functions should have type annotations
+- Use modern syntax: `list[T]`, `dict[K, V]`, `X | Y` for unions
+- Import types from `typing` only when necessary
+
+## Pull Request Process
+
+### 1. Fork and Branch
+
+```bash
+# Fork the repository on GitHub
+# Clone your fork
+git clone https://github.com/YOUR_USERNAME/tenrec.git
+
+# Create a feature branch
+git checkout -b feature/amazing-feature
+```
+
+### 2. Make Changes
+
+- Write clear, focused commits
+- Follow the code style guidelines
+- Add tests for new functionality
+- Update documentation as needed
+
+### 3. Test Your Changes
+
+```bash
+# Run linters
+ruff check .
+ruff format --check .
+
+# Run tests
+IDADIR="/path/to/ida" uv run pytest tenrec/tests/ -m unit
+```
+
+### 4. Submit PR
+
+```bash
+# Push to your fork
+git push origin feature/amazing-feature
+
+# Open a Pull Request on GitHub
+```
+
+### PR Guidelines
+
+- Use clear, descriptive titles
+- Reference related issues (e.g., "Fixes #123")
+- Include a description of changes
+- Keep PRs focused on a single feature/fix
+
+## Commit Guidelines
+
+### Message Format
+
+```
+<type>: <short description>
+
+<optional body with more details>
+```
+
+### Types
+
+- `feat`: New feature
+- `fix`: Bug fix
+- `docs`: Documentation changes
+- `refactor`: Code refactoring
+- `test`: Test additions/changes
+- `chore`: Maintenance tasks
+
+### Examples
+
+```
+feat: Add crypto detection plugin
+
+Implements detection of common cryptographic constants
+and patterns in analyzed binaries.
+
+Closes #42
+```
+
+```
+fix: Handle missing function in xrefs plugin
+
+Return empty list instead of raising exception when
+function is not found at specified address.
+```
+
+## Adding New Plugins
+
+### Built-in Plugins
+
+1. Create `tenrec/plugins/plugins/newplugin.py`
+2. Inherit from `PluginBase`, implement operations
+3. Register in `pyproject.toml` entry points:
+
+```toml
+[project.entry-points."tenrec.plugins"]
+newplugin = "tenrec.plugins.plugins.newplugin:NewPlugin"
+```
+
+4. Add to `DEFAULT_PLUGINS` in `tenrec/plugins/plugins/__init__.py`
+5. Add unit tests in `tenrec/tests/unit/test_newplugin_plugin.py`
+
+### External Plugins
+
+See [Plugin Development Guide](plugin-development.md) for creating standalone plugins.
+
+## Testing Requirements
+
+- All new features must include tests
+- Unit tests should use mocks (no real IDA database)
+- Use `@pytest.mark.unit` for unit tests
+- Aim for >80% coverage on new code
+
+## Documentation
+
+- Update `README.md` for user-facing changes
+- Update `agent_docs/` for developer documentation
+- Add docstrings to new public functions
+- Use Google-style docstring format
+
+## Getting Help
+
+- Open an issue for bugs or feature requests
+- Use discussions for questions
+- Check existing issues before creating new ones

--- a/agent_docs/integrations.md
+++ b/agent_docs/integrations.md
@@ -1,0 +1,191 @@
+# MCP Client Integrations
+
+Guide for integrating tenrec with various MCP clients.
+
+## Supported Clients (Auto-Install)
+
+The `tenrec install` command automatically configures these clients:
+
+| Client | Website |
+|--------|---------|
+| CLine | https://cline.bot/ |
+| Roo Code | https://github.com/RooCodeInc/Roo-Code |
+| Kilo Code | https://kilocode.ai/ |
+| Claude Desktop | https://claude.ai/download |
+| Cursor | https://cursor.com/ |
+| Windsurf | https://windsurf.com/ |
+| Claude Code | https://anthropic.com/claude-code |
+| LM Studio | https://lmstudio.ai/ |
+
+```bash
+tenrec install
+```
+
+The installer will prompt you to select which clients to configure.
+
+## Manual Integration
+
+For clients not yet supported by the installer, configure manually.
+
+### Generic MCP Configuration
+
+Most MCP clients use a JSON configuration file. Add tenrec as a server:
+
+```json
+{
+  "mcpServers": {
+    "tenrec": {
+      "command": "uvx",
+      "args": ["tenrec", "run"],
+      "env": {
+        "IDADIR": "/path/to/ida"
+      }
+    }
+  }
+}
+```
+
+### Configuration Locations
+
+| Client | Config Path |
+|--------|-------------|
+| Claude Desktop (macOS) | `~/Library/Application Support/Claude/claude_desktop_config.json` |
+| Claude Desktop (Windows) | `%APPDATA%\Claude\claude_desktop_config.json` |
+| Claude Code | `~/.claude.json` or project `.claude.json` |
+| Cursor | `.cursor/mcp.json` in project |
+| Windsurf | `.windsurf/mcp.json` in project |
+
+## Codex Integration
+
+OpenAI Codex requires manual configuration.
+
+### Prerequisites
+
+- Codex CLI installed (https://github.com/openai/codex/releases)
+- Azure OpenAI or OpenAI API key
+- tenrec installed (`uv tool install tenrec`)
+
+### Configuration
+
+Create `~/.codex/config.toml`:
+
+```toml
+# Model configuration
+model = "gpt-4.1"
+model_provider = "azure"
+preferred_auth_method = "apikey"
+
+# Azure provider settings
+[model_providers.azure]
+name = "Azure"
+base_url = "https://<your_deployment>.openai.azure.com/openai"
+env_key = "AZURE_OPENAI_API_KEY"
+query_params = { api-version = "2025-04-01-preview" }
+wire_api = "responses"
+model_reasoning_effort = "high"
+
+# Trust configuration
+[projects."/tmp"]
+trust_level = "trusted"
+
+# Tenrec MCP server
+[mcp_servers.tenrec]
+command = "uvx"
+args = ["tenrec", "run"]
+env = { "IDADIR" = "/path/to/ida" }
+```
+
+### Environment Setup
+
+```bash
+# Set API key (Azure example)
+export AZURE_OPENAI_API_KEY="your-api-key-here"
+
+# Or for OpenAI
+export OPENAI_API_KEY="your-api-key-here"
+```
+
+### Testing
+
+```bash
+# Verify Codex setup
+codex "Write me a Haiku"
+
+# Test with tenrec
+codex "Use tenrec to open a session on /path/to/binary.exe and list functions"
+```
+
+### Azure OpenAI Notes
+
+- Use a supported region for the [Responses API](https://learn.microsoft.com/en-us/azure/ai-foundry/openai/how-to/responses)
+- Deploy GPT-4.1 or compatible model in your workspace
+- API keys are found in Azure AI Foundry Overview page
+
+## Transport Options
+
+Tenrec supports multiple transports:
+
+| Transport | Flag | Use Case |
+|-----------|------|----------|
+| stdio | `--transport stdio` | Default, most clients |
+| http | `--transport http` | REST integration |
+| sse | `--transport sse` | Server-sent events |
+| streamable-http | `--transport streamable-http` | Large responses |
+
+Example with SSE:
+
+```json
+{
+  "mcpServers": {
+    "tenrec": {
+      "command": "uvx",
+      "args": ["tenrec", "run", "--transport", "sse"],
+      "env": {
+        "IDADIR": "/path/to/ida"
+      }
+    }
+  }
+}
+```
+
+## Troubleshooting
+
+### Common Issues
+
+**"IDADIR not set"**
+- Ensure `IDADIR` environment variable points to IDA installation
+- In config files, set it in the `env` section
+
+**"Permission denied"**
+- Check file permissions on IDA installation
+- Verify tenrec is installed correctly: `which tenrec`
+
+**"Plugin not found"**
+- Verify plugin is installed: `tenrec plugins list`
+- Check entry points in plugin's `pyproject.toml`
+
+### Debug Mode
+
+Enable debug logging:
+
+```bash
+export TENREC_DEBUG=1
+tenrec run
+```
+
+Or in config:
+
+```json
+{
+  "mcpServers": {
+    "tenrec": {
+      "command": "uvx",
+      "args": ["tenrec", "run"],
+      "env": {
+        "IDADIR": "/path/to/ida",
+        "TENREC_DEBUG": "1"
+      }
+    }
+  }
+}
+```

--- a/agent_docs/plugin-development.md
+++ b/agent_docs/plugin-development.md
@@ -1,0 +1,279 @@
+# Plugin Development Guide
+
+This guide covers creating custom plugins for tenrec.
+
+## Quick Start
+
+A minimal plugin requires:
+
+1. Inherit from `PluginBase`
+2. Define `name` (snake_case), `version` (semver), and `instructions`
+3. Decorate methods with `@operation()`
+
+```python
+from tenrec.plugins.models import PluginBase, Instructions, operation
+
+class MyPlugin(PluginBase):
+    """Plugin description for documentation."""
+
+    name = "my_plugin"
+    version = "1.0.0"
+    instructions = Instructions(
+        purpose="What this plugin does",
+        interaction_style=["How to use it effectively"],
+        examples=["my_plugin_operation_name()"],
+        anti_examples=["What NOT to do"],
+    )
+
+    @operation()
+    def operation_name(self) -> dict:
+        """Operation description for the LLM."""
+        # Access IDA database via self.database
+        return {"result": "value"}
+```
+
+## Plugin Structure
+
+### Required Attributes
+
+| Attribute | Type | Validation |
+|-----------|------|------------|
+| `name` | `str` | Must be snake_case, valid Python identifier |
+| `version` | `str` | Must be semver format (X.Y.Z) |
+| `instructions` | `Instructions` | Guides LLM usage |
+
+### The `Instructions` Model
+
+```python
+class Instructions(BaseModel):
+    purpose: str              # What the plugin does
+    interaction_style: list[str]  # How to use effectively
+    examples: list[str]       # Example usage
+    anti_examples: list[str]  # What NOT to do
+```
+
+### The `@operation()` Decorator
+
+Marks methods as MCP-exposed tools:
+
+```python
+@operation()
+def get_data(self, address: int) -> list[dict]:
+    """Get data at address.
+
+    :param address: Memory address to query
+    :return: List of data items
+    """
+    ...
+```
+
+Decorator options:
+
+- `options`: List of `OperationParameterBase` instances (e.g., `PaginatedParameter`)
+- `unsafe`: Boolean flag for potentially destructive operations
+
+## Working with Addresses
+
+Use `HexEA` model for addresses - ensures hex formatting familiar to reverse engineers:
+
+```python
+from tenrec.plugins.models import HexEA
+
+@operation()
+def get_function(self, address: HexEA) -> dict:
+    # address is automatically validated and formatted
+    func = self.database.functions.get_at(address)
+    return {"name": func.name, "start": str(address)}
+```
+
+## Accessing the IDA Database
+
+Plugins receive `self.database` (an `ida_domain.Database` instance) at runtime:
+
+```python
+@operation()
+def list_functions(self) -> list[dict]:
+    functions = []
+    for func in self.database.functions.get_all():
+        functions.append({
+            "name": func.name,
+            "start": hex(func.start_ea),
+            "end": hex(func.end_ea),
+        })
+    return functions
+```
+
+Common database APIs:
+
+- `self.database.functions` - Function queries
+- `self.database.xrefs` - Cross-references
+- `self.database.names` - Symbol names
+- `self.database.segments` - Memory segments
+- `self.database.strings` - String literals
+- `self.database.comments` - Comments
+- `self.database.types` - Type information
+- `self.database.bytes` - Raw bytes
+- `self.database.entries` - Entry points
+
+## Custom Operation Parameters
+
+For reusable parameter patterns across operations, implement `OperationParameterBase`:
+
+```python
+from tenrec.plugins.models.parameters import OperationParameterBase
+
+class MyCustomParameter(OperationParameterBase):
+    name = "my_parameter"
+
+    def hook_apply_signature(self, signature):
+        """Add parameters to the function signature."""
+        # Add new parameters
+        return modified_signature
+
+    def hook_apply_annotations(self, annotations):
+        """Update type annotations."""
+        return modified_annotations
+
+    def hook_pre_call(self, context, *args, **kwargs):
+        """Process arguments before the operation call."""
+        # Extract custom args, store in context
+        return args, kwargs
+
+    def hook_post_call(self, context, result):
+        """Process result after the operation call."""
+        # Transform result based on context
+        return modified_result
+```
+
+### Built-in: `PaginatedParameter`
+
+Adds `offset` and `limit` parameters for paginating list results:
+
+```python
+from tenrec.plugins.models.parameters import PaginatedParameter
+
+@operation(options=[PaginatedParameter(default_offset=0, default_limit=100)])
+def get_all_strings(self) -> list[dict]:
+    """Returns paginated string results."""
+    return self.database.strings.get_all()
+```
+
+Response format:
+
+```json
+{
+  "total": 1500,
+  "offset": 0,
+  "limit": 100,
+  "data": [...]
+}
+```
+
+## Packaging Your Plugin
+
+### pyproject.toml Structure
+
+```toml
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[project]
+name = "my-tenrec-plugin"
+version = "1.0.0"
+dependencies = ["tenrec"]
+
+[project.entry-points."tenrec.plugins"]
+my_plugin = "my_package.plugins:MyPlugin"
+```
+
+The entry point format is: `plugin_name = "module.path:ClassName"`
+
+### Installation Methods
+
+```bash
+# From PyPI
+tenrec plugins add --plugin "my-tenrec-plugin"
+
+# From git repo
+tenrec plugins add --plugin "git+https://github.com/user/repo"
+
+# From local path
+tenrec plugins add --plugin "/path/to/plugin"
+```
+
+## Best Practices
+
+1. **Clear docstrings**: LLMs use docstrings to understand operations
+2. **Type annotations**: Always annotate parameters and return types
+3. **Use `HexEA`**: For address parameters, ensures consistent hex formatting
+4. **Descriptive `Instructions`**: Guide LLMs on when/how to use your plugin
+5. **Return dicts/lists**: Avoid returning raw IDA objects
+6. **Handle missing data**: Return `None` or empty results gracefully
+
+## Example: Complete Plugin
+
+```python
+from tenrec.plugins.models import PluginBase, Instructions, operation, HexEA
+from tenrec.plugins.models.parameters import PaginatedParameter
+
+
+class CryptoAnalysisPlugin(PluginBase):
+    """Analyze cryptographic patterns in binaries."""
+
+    name = "crypto_analysis"
+    version = "1.0.0"
+    instructions = Instructions(
+        purpose="Detect and analyze cryptographic constants and patterns",
+        interaction_style=[
+            "Use find_constants() first to locate crypto patterns",
+            "Then use analyze_function() on suspicious functions",
+        ],
+        examples=[
+            "crypto_analysis_find_constants()",
+            "crypto_analysis_analyze_function(address=0x401000)",
+        ],
+        anti_examples=[
+            "Don't call analyze_function without finding constants first",
+        ],
+    )
+
+    CRYPTO_CONSTANTS = {
+        0x67452301: "MD5/SHA-1 init",
+        0xEFCDAB89: "MD5/SHA-1 init",
+        # ... more constants
+    }
+
+    @operation(options=[PaginatedParameter()])
+    def find_constants(self) -> list[dict]:
+        """Find known cryptographic constants in the binary.
+
+        :return: List of found constants with locations
+        """
+        results = []
+        for segment in self.database.segments.get_all():
+            # Search logic here
+            pass
+        return results
+
+    @operation()
+    def analyze_function(self, address: HexEA) -> dict:
+        """Analyze a function for cryptographic patterns.
+
+        :param address: Function address to analyze
+        :return: Analysis results including detected algorithms
+        """
+        func = self.database.functions.get_at(address)
+        if not func:
+            return {"error": "Function not found"}
+
+        pseudocode = self.database.functions.get_pseudocode(address)
+        # Analysis logic here
+
+        return {
+            "function": func.name,
+            "address": str(address),
+            "algorithms": [],
+            "confidence": 0.0,
+        }
+```

--- a/agent_docs/roadmap.md
+++ b/agent_docs/roadmap.md
@@ -1,0 +1,51 @@
+# Roadmap
+
+Planned features and future work for tenrec.
+
+## Planned Features
+
+### Enhanced Plugin System
+
+- Dynamic plugin loading without server restart
+- Hot-reload support for development
+- Plugin versioning and compatibility checks
+
+### Performance Optimizations
+
+- Result caching for expensive operations
+- Batch operations for multiple queries
+- Lazy loading of analysis data
+
+### Additional Plugin Ideas
+
+- **Vulnerability detection**: Pattern matching for common vulnerabilities
+- **Binary diffing**: Compare two binaries for changes
+- **Automated unpacking**: Detect and handle packed binaries
+- **ML-based analysis**: Machine learning integration for pattern recognition
+- **Signature matching**: YARA and other signature formats
+
+### Integration Improvements
+
+- Better integration with other reverse engineering tools
+- Export formats for common analysis tools
+- Import analysis from external sources
+
+### Documentation
+
+- Expanded API documentation
+- Video tutorials
+- Example analysis workflows
+
+## Windows Support
+
+Windows support is currently in progress. See [Issue #9](https://github.com/axelmierczuk/tenrec/issues/9) for details and updates.
+
+## Contributing Ideas
+
+Have an idea for tenrec? We welcome contributions:
+
+- Open an issue to discuss new features
+- Submit a PR with your implementation
+- Share your custom plugins with the community
+
+See [Contributing Guide](contributing.md) for details.

--- a/agent_docs/testing.md
+++ b/agent_docs/testing.md
@@ -1,0 +1,265 @@
+# Testing Guide
+
+This guide covers testing patterns for tenrec and custom plugins.
+
+## Running Tests
+
+```bash
+# Run all tests
+IDADIR="/path/to/ida" uv run pytest tenrec/tests/
+
+# Run specific test module
+IDADIR="/path/to/ida" uv run pytest tenrec/tests/unit/test_functions_plugin.py
+
+# Run with coverage report
+IDADIR="/path/to/ida" uv run pytest tenrec/tests/ --cov=tenrec --cov-report=html
+
+# Run with verbose output
+IDADIR="/path/to/ida" uv run pytest tenrec/tests/ -v
+
+# Run only unit tests (no IDA database required)
+IDADIR="/path/to/ida" uv run pytest tenrec/tests/ -m unit
+```
+
+## Test Structure
+
+Tests are located in `tenrec/tests/unit/` with one file per plugin:
+
+```
+tenrec/tests/
+├── conftest.py              # Shared fixtures
+└── unit/
+    ├── test_functions_plugin.py
+    ├── test_xrefs_plugin.py
+    ├── test_names_plugin.py
+    └── ...
+```
+
+## Test Markers
+
+Use markers to categorize tests:
+
+| Marker | Description |
+|--------|-------------|
+| `@pytest.mark.unit` | Unit tests, no real IDA database required |
+| `@pytest.mark.integration` | Integration tests with real IDA databases |
+| `@pytest.mark.slow` | Time-intensive tests |
+| `@pytest.mark.fixture` | Tests requiring pre-built database fixtures |
+
+## Available Fixtures
+
+### `mock_ida_database`
+
+Complete mock of `ida_domain.Database` with all sub-APIs:
+
+```python
+@pytest.fixture
+def mock_ida_database() -> Mock:
+    db = Mock(spec=Database)
+
+    # Metadata
+    db.metadata = DatabaseMetadata(
+        path="test_binary.exe",
+        md5="d41d8cd98f00b204e9800998ecf8427e",
+        base_address=0x400000,
+        bitness=64,
+        architecture="x86_64",
+        format="PE",
+    )
+
+    # Functions API
+    db.functions = Mock()
+    db.functions.get_all = Mock(return_value=[])
+    db.functions.get_at = Mock(return_value=None)
+    db.functions.get_pseudocode = Mock(return_value=["int main() {", "    return 0;", "}"])
+
+    # Other APIs: xrefs, names, segments, strings, comments, types, bytes, entries
+    return db
+```
+
+### `mock_database_handler`
+
+Mock `DatabaseHandler` with ready status:
+
+```python
+@pytest.fixture
+def mock_database_handler(mock_ida_database) -> DatabaseHandler:
+    handler = Mock(spec=DatabaseHandler)
+    handler.database = mock_ida_database
+    handler.status = Status.READY
+    handler.is_open = Mock(return_value=True)
+    return handler
+```
+
+### `mock_function_data`
+
+Sample `FunctionData` object:
+
+```python
+@pytest.fixture
+def mock_function_data() -> FunctionData:
+    return FunctionData(
+        start_ea=0x401000,
+        end_ea=0x401050,
+        name="test_function",
+    )
+```
+
+### `temp_database_dir`
+
+Temporary directory for test databases:
+
+```python
+@pytest.fixture
+def temp_database_dir() -> Generator[Path]:
+    temp_dir = tempfile.mkdtemp(prefix="ida_test_")
+    yield Path(temp_dir)
+    shutil.rmtree(temp_dir, ignore_errors=True)
+```
+
+### `ida_options`
+
+Default IDA command options:
+
+```python
+@pytest.fixture
+def ida_options() -> IdaCommandOptions:
+    return IdaCommandOptions(
+        auto_analysis=False,  # Disable for faster tests
+        log_file=None,
+    )
+```
+
+## Writing Plugin Tests
+
+### Basic Pattern
+
+```python
+import pytest
+from unittest.mock import MagicMock
+
+from tenrec.plugins.plugins.functions import FunctionsPlugin
+
+
+class TestFunctionsPlugin:
+    @pytest.fixture
+    def plugin(self, mock_ida_database):
+        plugin = FunctionsPlugin()
+        plugin.database = mock_ida_database
+        return plugin
+
+    @pytest.mark.unit
+    def test_get_all_returns_empty_list_when_no_functions(self, plugin):
+        plugin.database.functions.get_all.return_value = []
+        result = plugin.get_all()
+        assert result == []
+
+    @pytest.mark.unit
+    def test_get_at_returns_function_data(self, plugin, mock_function_data):
+        mock_func_t = MagicMock()
+        plugin.database.functions.get_at.return_value = mock_func_t
+
+        with patch.object(FunctionData, 'from_func_t', return_value=mock_function_data):
+            result = plugin.get_at(address=0x401000)
+
+        assert result.name == "test_function"
+```
+
+### Testing Operations with Side Effects
+
+```python
+@pytest.mark.unit
+def test_set_name_calls_database(self, plugin):
+    plugin.database.functions.set_name.return_value = True
+
+    result = plugin.set_name(address=0x401000, name="new_name")
+
+    plugin.database.functions.set_name.assert_called_once_with(0x401000, "new_name")
+    assert result["success"] is True
+```
+
+### Testing Paginated Operations
+
+```python
+@pytest.mark.unit
+def test_get_all_with_pagination(self, plugin, mock_function_data_list):
+    plugin.database.functions.get_all.return_value = mock_function_data_list
+
+    # Pagination is handled by the decorator, test the raw return
+    result = plugin.get_all()
+
+    assert len(result) == 3
+```
+
+## Mocking IDA-specific Types
+
+For operations that transform IDA types:
+
+```python
+from unittest.mock import patch, MagicMock
+
+@pytest.mark.unit
+def test_transforms_func_t_to_function_data(self, plugin):
+    mock_func_t = MagicMock()
+    mock_func_t.start_ea = 0x401000
+    mock_func_t.end_ea = 0x401050
+
+    plugin.database.functions.get_all.return_value = [mock_func_t]
+
+    expected = FunctionData(start_ea=0x401000, end_ea=0x401050, name="func")
+    with patch.object(FunctionData, 'from_func_t', return_value=expected):
+        result = plugin.get_all()
+
+    assert result[0].start_ea == 0x401000
+```
+
+## Integration Tests
+
+For tests requiring real IDA databases:
+
+```python
+@pytest.mark.integration
+@pytest.mark.fixture
+def test_real_database_operations(self, real_database_handler):
+    """Test with actual IDA database (requires fixture)."""
+    plugin = FunctionsPlugin()
+    plugin.database = real_database_handler.database
+
+    functions = plugin.get_all()
+    assert len(functions) > 0
+```
+
+Integration tests require:
+
+1. Pre-built database fixtures in `tenrec/tests/fixtures/databases/`
+2. `IDADIR` environment variable set
+3. Appropriate test markers
+
+## Testing Custom Plugins
+
+```python
+import pytest
+from unittest.mock import MagicMock
+
+from my_plugin import CryptoAnalysisPlugin
+
+
+class TestCryptoAnalysisPlugin:
+    @pytest.fixture
+    def plugin(self, mock_ida_database):
+        plugin = CryptoAnalysisPlugin()
+        plugin.database = mock_ida_database
+        return plugin
+
+    @pytest.mark.unit
+    def test_find_constants_returns_list(self, plugin):
+        plugin.database.segments.get_all.return_value = []
+        result = plugin.find_constants()
+        assert isinstance(result, list)
+
+    @pytest.mark.unit
+    def test_analyze_function_returns_error_when_not_found(self, plugin):
+        plugin.database.functions.get_at.return_value = None
+        result = plugin.analyze_function(address=0x401000)
+        assert "error" in result
+```


### PR DESCRIPTION
## Summary

- Restructure README.md from ~677 lines to ~178 lines for better scanning
- Add CLAUDE.md establishing coding patterns and architecture overview for AI assistants
- Create agent_docs/ folder with topic-based progressive disclosure documentation

## Changes

### README.md
Streamlined to include only essential information:
- Features and built-in plugins overview
- Demo section
- Installation and quick start
- Links to detailed documentation

### CLAUDE.md (new)
AI assistant guide covering:
- Architecture overview with directory structure
- Code style summary (ruff.toml settings)
- Plugin development patterns
- Testing patterns
- Common tasks

### agent_docs/ (new folder)
| File | Description |
|------|-------------|
| `architecture.md` | System design, components, data flow |
| `plugin-development.md` | Complete plugin creation guide |
| `cli-reference.md` | All CLI commands with full options |
| `testing.md` | Testing patterns, fixtures, examples |
| `contributing.md` | Development setup, code style, PR process |
| `integrations.md` | MCP client setup including Codex |
| `roadmap.md` | Future plans |

## Test plan

- [ ] Verify all internal links work
- [ ] Review README for clarity and accuracy
- [ ] Review CLAUDE.md for completeness
- [ ] Check agent_docs covers all moved content